### PR TITLE
Add category column to listings and update schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :development, :test do
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
-  gem "brakeman", require: false
+  gem "brakeman", "7.0.2", require: false
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
-    brakeman (7.0.0)
+    brakeman (7.0.2)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -363,7 +363,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt (~> 3.1.7)
   bootsnap
-  brakeman
+  brakeman (= 7.0.2)
   capybara
   debug
   importmap-rails

--- a/db/migrate/20250405024547_add_category_to_listings.rb
+++ b/db/migrate/20250405024547_add_category_to_listings.rb
@@ -1,0 +1,5 @@
+class AddCategoryToListings < ActiveRecord::Migration[8.0]
+  def change
+    add_column :listings, :category, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_27_013506) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_05_024547) do
   create_table "listings", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -19,6 +19,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_27_013506) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "location"
+    t.string "category"
     t.index ["User_id"], name: "index_listings_on_User_id"
   end
 


### PR DESCRIPTION
Adds a `category` string column to the `listings` table

- Updated schema.rb
- Migration file: 20250405024547_add_category_to_listings.rb
